### PR TITLE
use kid as file name, remove public

### DIFF
--- a/charts/openlane/templates/openlane.yaml
+++ b/charts/openlane/templates/openlane.yaml
@@ -100,6 +100,4 @@ spec:
             secretName: token-keys
             items:
               - key: tls.key
-                path: token-private.pem
-              - key: tls.crt
-                path: token-public.pem
+                path: 01JZ6M4SGPSBJY8ENJ53PG7GYS.pem


### PR DESCRIPTION
we don't persist the public key, the map is the kid -> private key with the name of the `.pem` as the kid. 