### PR TITLE
feat: fga and core changes for prod

### DIFF
--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -1,5 +1,5 @@
 openfga:
-  replicaCount: 3
+  replicaCount: 2
 
   image:
     repository: openfga/openfga
@@ -11,7 +11,9 @@ openfga:
   fullnameOverride: ""
   serviceAccount:
     create: true
-    annotations: {}
+    annotations:
+      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/sync-wave: "-2"
     name: ""
 
   annotations: {}
@@ -19,7 +21,9 @@ openfga:
   podAnnotations: {}
   podExtraLabels: {}
 
-  extraEnvVars: []
+  extraEnvVars: 
+    - name: OPENFGA_MAX_CHECKS_PER_BATCH_CHECK
+      value: "500"
   extraVolumes: []
   extraVolumeMounts: []
   extraInitContainers: []
@@ -88,13 +92,13 @@ openfga:
     secretKeys:
       uriKey: uri
     maxCacheSize:
-    maxOpenConns: 8
-    maxIdleConns: 8
+    maxOpenConns: 20
+    maxIdleConns: 20
     connMaxIdleTime:
     connMaxLifetime:
-    applyMigrations: false
-    waitForMigrations: false
-    migrationType: initContainer
+    applyMigrations: true
+    waitForMigrations: true
+    migrationType: job
     migrations:
       resources: {}
       image:
@@ -139,7 +143,7 @@ openfga:
       issuer:
 
   playground:
-    enabled: true
+    enabled: false
     port: 3000
 
   profiler:
@@ -154,7 +158,7 @@ openfga:
   checkQueryCache:
     enabled: true
     limit:
-    ttl: 30s
+    ttl: 60s
 
   experimentals:
     - enable-check-optimizations
@@ -162,16 +166,16 @@ openfga:
   maxTuplesPerWrite:
   maxTypesPerAuthorizationModel:
   maxAuthorizationModelSizeInBytes:
-  maxConcurrentReadsForCheck:
-  maxConcurrentReadsForListObjects:
-  maxConcurrentReadsForListUsers:
+  maxConcurrentReadsForCheck: 100
+  maxConcurrentReadsForListObjects: 100
+  maxConcurrentReadsForListUsers: 100
   changelogHorizonOffset:
   resolveNodeLimit:
   resolveNodeBreadthLimit:
   listObjectsDeadline: 5s
   listObjectsMaxResults: 10000
   listUsersDeadline: 5s
-  listUsersMaxResults: 10000
+  listUsersMaxResults: 1000
   requestTimeout: 5s
   requestDurationDatastoreQueryCountBuckets: [50, 200]
   allowWriting1_0Models:
@@ -221,9 +225,11 @@ openfga:
     extraInitContainers: []
     sidecars: []
     annotations:
-      helm.sh/hook: "post-install, post-upgrade, post-rollback"
-      argocd.argoproj.io/sync-wave: "0"
-    labels: {}
+      helm.sh/hook: null
+      helm.sh/hook-weight: null
+      helm.sh/hook-delete-policy: null
+      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/sync-wave: "-1"
     timeout:
 
   testPodSpec: {}

--- a/charts/openlane/templates/openlane.yaml
+++ b/charts/openlane/templates/openlane.yaml
@@ -44,6 +44,14 @@ spec:
               value: "true"
             - name: CORE_KEYWATCHER_KEYDIR
               value: /keys
+            - name: CORE_SERVER_GRAPHPOOL_MAXWORKERS
+              value: '200'
+            - name: CORE_ENTCONFIG_MAXPOOLSIZE
+              value: '200'
+            - name: CORE_DB_MAXCONNECTIONS
+              value: '8'
+            - name: CORE_DB_MAXIDLECONNECTIONS
+              value: '8'
           envFrom:
             - secretRef:
                 name: openlane-app-secret

--- a/charts/openlane/values.yaml
+++ b/charts/openlane/values.yaml
@@ -12,7 +12,7 @@ openlane:
     # Container image repository
     repository: ghcr.io/theopenlane/core
     # Image tag to deploy
-    tag: "v0.20.10"
+    tag: "v0.21.0"
     # Kubernetes pull policy for the image
     pullPolicy: IfNotPresent
   # Service account used by the API pods

--- a/charts/openlane/values.yaml
+++ b/charts/openlane/values.yaml
@@ -263,19 +263,20 @@ openlane:
   api:
     # Additional annotations to apply to the main ConfigMap
     commonAnnotations: {}
-  podMonitor:
-    # -- If `true`, create a PodMonitor resource to support the Prometheus Operator.
-    enabled: true
-    # -- Additional labels for the PodMonitor.
-    additionalLabels: {}
-    # -- Annotations to add to the PodMonitor.
-    annotations: {}
-    # -- (string) If set create the PodMonitor in an alternate namespace.
-    namespace:  # @schema type:[string, null]; default: null
-    # -- (string) Interval at which Prometheus scrapes metrics.
-    interval:  # @schema type:[string, null]; default: null
-    # -- (string) Timeout if metrics cannot be retrieved in given time interval.
-    scrapeTimeout:  # @schema type:[string, null]; default: null
+    
+podMonitor:
+  # -- If `true`, create a PodMonitor resource to support the Prometheus Operator.
+  enabled: true
+  # -- Additional labels for the PodMonitor.
+  additionalLabels: {}
+  # -- Annotations to add to the PodMonitor.
+  annotations: {}
+  # -- (string) If set create the PodMonitor in an alternate namespace.
+  namespace:  # @schema type:[string, null]; default: null
+  # -- (string) Interval at which Prometheus scrapes metrics.
+  interval:  # @schema type:[string, null]; default: null
+  # -- (string) Timeout if metrics cannot be retrieved in given time interval.
+  scrapeTimeout:  # @schema type:[string, null]; default: null
 
 
 riverboat:


### PR DESCRIPTION
- disables fga playground
- uses 2 higher cpu replicas instead of 3, which will help with caching hits
- sets `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` to 500; backend currently is configured to 100 so we have space to change that
- increases cache ttl to `60s`
- sets max connections for core api
- bumps to latest core api version