### PR TITLE
🤖 Update Helm chart from core config (Build #6030)

### DIFF
--- a/charts/openlane/CHANGELOG.md
+++ b/charts/openlane/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 
+## [0.36.4] - 2025-10-01
+
+### Changed✅ Updated ConfigMap template
+\n- 🔄 Merged Helm values.yaml\n- 🔐 External secrets configuration updated\n- ✅ Updated ConfigMap template
+
+### Build Information
+- Build Number: 6030
+- Source Commit: 539700ae
+- Source Branch: main
+- Generated: 2025-10-01 18:26:04 UTC
+
+---
+
 ## [0.35.4] - 2025-09-30
 
 ### Changed✅ Updated ConfigMap template

--- a/charts/openlane/Chart.yaml
+++ b/charts/openlane/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.36.3
+version: 0.36.4
 apiVersion: v2
 appVersion: "v0.36.3"
 description: A Helm chart to deploy the core Openlane server on GKE clusters

--- a/charts/openlane/HELM.md
+++ b/charts/openlane/HELM.md
@@ -210,7 +210,7 @@ A Helm chart to deploy the core Openlane server on GKE clusters
 | openlane.coreConfiguration.sessions | object | `{"domain":"","httpOnly":true,"maxAge":3600,"sameSite":"Strict","secure":true}` | Sessions config for user sessions and cookies |
 | openlane.coreConfiguration.totp | object | `{"codeLength":6,"enabled":true,"issuer":"","recoveryCodeCount":16,"recoveryCodeLength":8,"redis":true}` | TOTP contains the configuration for the TOTP provider |
 | openlane.coreConfiguration.ratelimit | object | `{"burst":30,"enabled":false,"expires":"10m0s","limit":10}` | Ratelimit contains the configuration for the rate limiter |
-| openlane.coreConfiguration.objectStorage | object | `{"defaultBucket":"file_uploads","enabled":true,"keys":["uploadFile"],"localURL":"http://localhost:17608/files/","maxMemoryMB":0,"maxSizeMB":0,"provider":"","region":""}` | ObjectStorage contains the configuration for the object storage backend |
+| openlane.coreConfiguration.objectStorage | object | `{"defaultBucket":"file_uploads","enabled":true,"endpoint":"","keys":["uploadFile"],"localURL":"http://localhost:17608/files/","maxMemoryMB":0,"maxSizeMB":0,"provider":"","region":"","usePathStyle":false}` | ObjectStorage contains the configuration for the object storage backend |
 | openlane.coreConfiguration.objectStorage.enabled | bool | `true` | Enabled indicates if the store is enabled |
 | openlane.coreConfiguration.objectStorage.provider | string | `""` | Provider is the name of the provider, eg. disk, s3, will default to disk if nothing is set |
 | openlane.coreConfiguration.objectStorage.region | string | `""` | Region is the region for the storage provider |
@@ -219,6 +219,8 @@ A Helm chart to deploy the core Openlane server on GKE clusters
 | openlane.coreConfiguration.objectStorage.keys | list | `["uploadFile"]` | Keys is a list of keys to look for in the multipart form on the REST request if the keys are not found, the request upload will be skipped this is not used when uploading files with gqlgen and the graphql handler |
 | openlane.coreConfiguration.objectStorage.maxSizeMB | int | `0` | MaxUploadSizeMB is the maximum size of file uploads to accept in megabytes |
 | openlane.coreConfiguration.objectStorage.maxMemoryMB | int | `0` | MaxUploadMemoryMB is the maximum memory in megabytes to use when parsing a multipart form |
+| openlane.coreConfiguration.objectStorage.endpoint | string | `""` | Endpoint is used for other s3 compatible storage systems e.g minio, digial ocean spaces . they do not use the same s3 endpoint |
+| openlane.coreConfiguration.objectStorage.usePathStyle | bool | `false` | UsePathStyle is useful for other s3 compatible systems that use path styles not bucket.host path minio is a popular example here |
 | openlane.coreConfiguration.subscription | object | `{"enabled":false,"publicStripeKey":"","stripeBillingPortalSuccessURL":"https://console.openlane.com/organization-settings/billing","stripeCancellationReturnURL":"https://console.theopenlane.io/organization-settings/billing","stripeWebhookEvents":[],"stripeWebhookURL":"https://api.openlane.com/v1/stripe/webhook"}` | Entitlements contains the configuration for the entitlements service |
 | openlane.coreConfiguration.subscription.enabled | bool | `false` | Enabled determines if the entitlements service is enabled |
 | openlane.coreConfiguration.subscription.publicStripeKey | string | `""` | PublicStripeKey is the key for the stripe service |

--- a/charts/openlane/templates/core-configmap.yaml
+++ b/charts/openlane/templates/core-configmap.yaml
@@ -321,6 +321,8 @@ data:
   CORE_OBJECTSTORAGE_KEYS: {{ join "," .Values.openlane.coreConfiguration.objectStorage.keys | quote | default "uploadFile" }}
   CORE_OBJECTSTORAGE_MAXSIZEMB: {{ .Values.openlane.coreConfiguration.objectStorage.maxSizeMB | quote }}
   CORE_OBJECTSTORAGE_MAXMEMORYMB: {{ .Values.openlane.coreConfiguration.objectStorage.maxMemoryMB | quote }}
+  CORE_OBJECTSTORAGE_ENDPOINT: {{ .Values.openlane.coreConfiguration.objectStorage.endpoint | quote }}
+  CORE_OBJECTSTORAGE_USEPATHSTYLE: {{ .Values.openlane.coreConfiguration.objectStorage.usePathStyle | quote }}
   CORE_SUBSCRIPTION_ENABLED: {{ .Values.openlane.coreConfiguration.subscription.enabled | quote | default "false" }}
   CORE_SUBSCRIPTION_PUBLICSTRIPEKEY: {{ .Values.openlane.coreConfiguration.subscription.publicStripeKey | quote }}
 {{- if .Values.openlane.coreConfiguration.subscription.stripeWebhookURL }}

--- a/charts/openlane/values.yaml
+++ b/charts/openlane/values.yaml
@@ -478,6 +478,12 @@ openlane:
       maxSizeMB: 0 # @schema type:integer
       # -- MaxUploadMemoryMB is the maximum memory in megabytes to use when parsing a multipart form
       maxMemoryMB: 0 # @schema type:integer
+      # -- Endpoint is used for other s3 compatible storage systems e.g minio, digial ocean spaces .
+      # they do not use the same s3 endpoint
+      endpoint: "" # @schema type:string
+      # -- UsePathStyle is useful for other s3 compatible systems that use path styles not bucket.host path
+      # minio is a popular example here
+      usePathStyle: false # @schema type:boolean
     # -- Entitlements contains the configuration for the entitlements service
     subscription:
       # -- Enabled determines if the entitlements service is enabled


### PR DESCRIPTION
## 🤖 Helm Chart Update

Updates Helm chart from core config changes.

### Changes:
✅ Updated ConfigMap template

- 🔄 Merged Helm values.yaml
- 🔐 External secrets configuration updated
- ✅ Updated ConfigMap template
- 📈 Bumped chart version to 0.36.4
- 📝 Updated changelog with detailed changes

### Build:
- #6030 from `main`
- [`539700ae`](https://github.com/theopenlane/core/commit/539700ae97eb421391e92fc127541f20e80ab556)