### PR TITLE
🤖 Update Helm chart from core config (Build #6067)

### DIFF
--- a/charts/openlane/CHANGELOG.md
+++ b/charts/openlane/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 
+## [0.36.6] - 2025-10-02
+
+### Changed✅ Updated ConfigMap template
+\n- ✅ Updated ConfigMap template
+
+### Build Information
+- Build Number: 6067
+- Source Commit: 9963a049
+- Source Branch: main
+- Generated: 2025-10-02 04:29:24 UTC
+
+---
+
 ## [0.36.5] - 2025-10-01
 
 ### Changed✅ Updated ConfigMap template

--- a/charts/openlane/Chart.yaml
+++ b/charts/openlane/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.36.5
+version: 0.36.6
 apiVersion: v2
 appVersion: "v0.36.4"
 description: A Helm chart to deploy the core Openlane server on GKE clusters

--- a/charts/openlane/templates/core-configmap.yaml
+++ b/charts/openlane/templates/core-configmap.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     app: openlane
     component: config
+  annotations:
+    # This checksum will trigger deployment restarts when the ConfigMap changes
+    checksum/config: {{ .Values | toYaml | sha256sum }}
 data:
   CORE_REFRESHINTERVAL: {{ .Values.openlane.coreConfiguration.refreshInterval | quote | default "10m" }}
   CORE_SERVER_DEV: {{ .Values.openlane.coreConfiguration.server.dev | quote | default "false" }}


### PR DESCRIPTION
## 🤖 Helm Chart Update

Updates Helm chart from core config changes.

### Changes:
✅ Updated ConfigMap template

- ✅ Updated ConfigMap template
- 📈 Bumped chart version to 0.36.6
- 📝 Updated changelog with detailed changes

### Build:
- #6067 from `main`
- [`9963a049`](https://github.com/theopenlane/core/commit/9963a04958931763f4a97f342abaccac7202afcd)